### PR TITLE
Fix PHPUnit workflow dependencies

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,6 +15,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+          extensions: mbstring, intl, pdo_mysql, fileinfo
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-interaction
+
       - name: Copy .env.testing
         run: |
           cp .env.example .env


### PR DESCRIPTION
## Summary
- set up PHP 8.2 in the PHPUnit workflow
- install Composer dependencies before running Sail and tests

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cf2730894832eb3d72fe8ea59a932)