### PR TITLE
Release v0.1.2

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_run:
+    workflows:
+      - "Create Release Tag"
+    types: [completed]
 
 permissions:
   contents: write
@@ -11,6 +15,9 @@ permissions:
 
 jobs:
   sync:
+    if: >-
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- chore: ensure sync-main-to-dev runs after create-tag workflow or tag