### PR TITLE
Regenerate migration for JWT access token type

### DIFF
--- a/database/migrations/2025_11_29_055533_create_jwt_tokens_table.php
+++ b/database/migrations/2025_11_29_055533_create_jwt_tokens_table.php
@@ -21,7 +21,7 @@ return new class extends Migration
                 ->constrained('user_devices')
                 ->cascadeOnUpdate()
                 ->nullOnDelete();
-            $table->string('access_token', 255);
+            $table->text('access_token');
             $table->string('refresh_token', 255);
             $table->timestamp('expires_at');
             $table->timestamp('refresh_expires_at');

--- a/database/migrations/2025_12_04_120000_update_access_token_column_in_jwt_tokens_table.php
+++ b/database/migrations/2025_12_04_120000_update_access_token_column_in_jwt_tokens_table.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE `jwt_tokens` MODIFY `access_token` TEXT NOT NULL');
+    }
+
+    public function down(): void
+    {
+        DB::statement('ALTER TABLE `jwt_tokens` MODIFY `access_token` VARCHAR(255) NOT NULL');
+    }
+};

--- a/docs/XYZ LMS – Master Database Schema.md
+++ b/docs/XYZ LMS – Master Database Schema.md
@@ -114,7 +114,7 @@ Status: Production-Ready
 ## jwt_tokens
 - id
 - user_id
-- access_token (hashed)
+- access_token (TEXT, hashed)
 - refresh_token (hashed)
 - expires_at
 - refresh_expires_at


### PR DESCRIPTION
## Summary
- replace the earlier access token alteration migration with a sail-style migration file
- keep the access_token column alteration to TEXT for existing jwt_tokens data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930df8741cc832ebdc5cda04faa666f)