### PR TITLE
[LMS][TASK-16][#84] Instructor profile enrichment

### DIFF
--- a/app/Http/Controllers/Api/V1/InstructorController.php
+++ b/app/Http/Controllers/Api/V1/InstructorController.php
@@ -55,6 +55,7 @@ class InstructorController extends Controller
         /** @var array<string, mixed> $data */
         $data = $request->validated();
         $data['created_by'] = (int) $request->user()->id;
+        $data['avatar'] = $request->file('avatar');
 
         $instructor = $this->createAction->execute($data);
 
@@ -80,6 +81,7 @@ class InstructorController extends Controller
     {
         /** @var array<string, mixed> $data */
         $data = $request->validated();
+        $data['avatar'] = $request->file('avatar');
         $updated = $this->updateAction->execute($instructor, $data);
 
         return response()->json([

--- a/app/Http/Requests/Instructor/StoreInstructorRequest.php
+++ b/app/Http/Requests/Instructor/StoreInstructorRequest.php
@@ -7,6 +7,7 @@ namespace App\Http\Requests\Instructor;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Support\Arr;
 
 class StoreInstructorRequest extends FormRequest
 {
@@ -26,11 +27,40 @@ class StoreInstructorRequest extends FormRequest
             'bio_translations' => ['nullable', 'array'],
             'title_translations' => ['nullable', 'array'],
             'avatar_url' => ['nullable', 'string'],
+            'avatar' => ['sometimes', 'file', 'image', 'mimes:jpeg,jpg,png,webp', 'max:512000'],
             'email' => ['nullable', 'email'],
             'phone' => ['nullable', 'string'],
             'social_links' => ['nullable', 'array'],
             'social_links.*' => ['nullable', 'string'],
+            'metadata' => ['sometimes', 'array'],
         ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            $metadata = $this->input('metadata');
+            if (! is_array($metadata)) {
+                return;
+            }
+
+            $allowed = config('instructors.metadata_keys', []);
+            $unknown = array_diff(array_keys($metadata), $allowed);
+            if (! empty($unknown)) {
+                $validator->errors()->add('metadata', 'Unsupported metadata keys: '.implode(', ', $unknown));
+            }
+
+            foreach ($metadata as $key => $value) {
+                if (is_array($value)) {
+                    $invalid = Arr::first($value, static fn ($v): bool => ! is_string($v));
+                    if ($invalid !== null) {
+                        $validator->errors()->add("metadata.{$key}", 'Metadata arrays must contain only strings.');
+                    }
+                } elseif (! is_string($value) && ! is_numeric($value)) {
+                    $validator->errors()->add("metadata.{$key}", 'Metadata value must be a string, number, or array of strings.');
+                }
+            }
+        });
     }
 
     /**
@@ -70,6 +100,10 @@ class StoreInstructorRequest extends FormRequest
             'social_links' => [
                 'description' => 'Optional social/profile links.',
                 'example' => ['linkedin' => 'https://linkedin.com/in/johndoe'],
+            ],
+            'metadata' => [
+                'description' => 'Optional instructor metadata.',
+                'example' => ['specialization' => 'Math', 'languages' => ['en', 'ar']],
             ],
         ];
     }

--- a/app/Http/Requests/Instructor/UpdateInstructorRequest.php
+++ b/app/Http/Requests/Instructor/UpdateInstructorRequest.php
@@ -7,6 +7,7 @@ namespace App\Http\Requests\Instructor;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Support\Arr;
 
 class UpdateInstructorRequest extends FormRequest
 {
@@ -26,11 +27,40 @@ class UpdateInstructorRequest extends FormRequest
             'bio_translations' => ['sometimes', 'nullable', 'array'],
             'title_translations' => ['sometimes', 'nullable', 'array'],
             'avatar_url' => ['sometimes', 'nullable', 'string'],
+            'avatar' => ['sometimes', 'file', 'image', 'mimes:jpeg,jpg,png,webp', 'max:512000'],
             'email' => ['sometimes', 'nullable', 'email'],
             'phone' => ['sometimes', 'nullable', 'string'],
             'social_links' => ['sometimes', 'nullable', 'array'],
             'social_links.*' => ['nullable', 'string'],
+            'metadata' => ['sometimes', 'array'],
         ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            $metadata = $this->input('metadata');
+            if (! is_array($metadata)) {
+                return;
+            }
+
+            $allowed = config('instructors.metadata_keys', []);
+            $unknown = array_diff(array_keys($metadata), $allowed);
+            if (! empty($unknown)) {
+                $validator->errors()->add('metadata', 'Unsupported metadata keys: '.implode(', ', $unknown));
+            }
+
+            foreach ($metadata as $key => $value) {
+                if (is_array($value)) {
+                    $invalid = Arr::first($value, static fn ($v): bool => ! is_string($v));
+                    if ($invalid !== null) {
+                        $validator->errors()->add("metadata.{$key}", 'Metadata arrays must contain only strings.');
+                    }
+                } elseif (! is_string($value) && ! is_numeric($value)) {
+                    $validator->errors()->add("metadata.{$key}", 'Metadata value must be a string, number, or array of strings.');
+                }
+            }
+        });
     }
 
     /**
@@ -70,6 +100,10 @@ class UpdateInstructorRequest extends FormRequest
             'social_links' => [
                 'description' => 'Optional social/profile links.',
                 'example' => ['linkedin' => 'https://linkedin.com/in/johndoe'],
+            ],
+            'metadata' => [
+                'description' => 'Optional instructor metadata.',
+                'example' => ['specialization' => 'Physics'],
             ],
         ];
     }

--- a/app/Http/Resources/InstructorResource.php
+++ b/app/Http/Resources/InstructorResource.php
@@ -31,6 +31,7 @@ class InstructorResource extends JsonResource
             'email' => $instructor->email,
             'phone' => $instructor->phone,
             'social_links' => $instructor->social_links,
+            'metadata' => $instructor->metadata,
         ];
     }
 }

--- a/app/Models/Instructor.php
+++ b/app/Models/Instructor.php
@@ -22,6 +22,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string|null $email
  * @property string|null $phone
  * @property array<string, mixed>|null $social_links
+ * @property array<string, mixed>|null $metadata
  * @property int $created_by
  * @property-read Center|null $center
  * @property-read User $creator
@@ -44,6 +45,7 @@ class Instructor extends Model
         'email',
         'phone',
         'social_links',
+        'metadata',
         'created_by',
     ];
 
@@ -52,6 +54,7 @@ class Instructor extends Model
         'bio_translations' => 'array',
         'title_translations' => 'array',
         'social_links' => 'array',
+        'metadata' => 'array',
     ];
 
     /** @var array<int, string> */

--- a/app/Services/Instructors/InstructorService.php
+++ b/app/Services/Instructors/InstructorService.php
@@ -7,6 +7,9 @@ namespace App\Services\Instructors;
 use App\Models\Instructor;
 use App\Services\Instructors\Contracts\InstructorServiceInterface;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use RuntimeException;
 
 class InstructorService implements InstructorServiceInterface
 {
@@ -25,6 +28,9 @@ class InstructorService implements InstructorServiceInterface
      */
     public function create(array $data): Instructor
     {
+        $data = $this->prepareAvatar($data);
+        $data = $this->prepareMetadata($data);
+
         return Instructor::create($data);
     }
 
@@ -33,6 +39,9 @@ class InstructorService implements InstructorServiceInterface
      */
     public function update(Instructor $instructor, array $data): Instructor
     {
+        $data = $this->prepareAvatar($data);
+        $data = $this->prepareMetadata($data, $instructor);
+
         $instructor->update($data);
 
         return $instructor->fresh(['center', 'creator']) ?? $instructor;
@@ -46,5 +55,64 @@ class InstructorService implements InstructorServiceInterface
     public function find(int $id): ?Instructor
     {
         return Instructor::with(['center', 'creator', 'courses'])->find($id);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    private function prepareAvatar(array $data): array
+    {
+        $avatar = $data['avatar'] ?? null;
+
+        if ($avatar instanceof UploadedFile) {
+            $disk = config('filesystems.default', 'public');
+            $path = Storage::disk($disk)->putFile('instructors/avatars', $avatar);
+            if ($path === false) {
+                throw new RuntimeException('Failed to store instructor avatar.');
+            }
+            $data['avatar_url'] = Storage::disk($disk)->url($path);
+        }
+
+        unset($data['avatar']);
+
+        return $data;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    private function prepareMetadata(array $data, ?Instructor $instructor = null): array
+    {
+        $metadata = $data['metadata'] ?? null;
+        unset($data['metadata']);
+
+        if ($metadata === null) {
+            return $data;
+        }
+
+        $allowed = config('instructors.metadata_keys', []);
+        $clean = [];
+
+        foreach ($metadata as $key => $value) {
+            if (! in_array($key, $allowed, true)) {
+                continue;
+            }
+
+            if (is_array($value)) {
+                $clean[$key] = array_values(array_filter($value, static fn ($item): bool => is_string($item)));
+
+                continue;
+            }
+
+            if (is_string($value) || is_numeric($value)) {
+                $clean[$key] = $value;
+            }
+        }
+
+        $data['metadata'] = $clean;
+
+        return $data;
     }
 }

--- a/config/instructors.php
+++ b/config/instructors.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'metadata_keys' => [
+        'title',
+        'specialization',
+        'experience_years',
+        'education',
+        'certifications',
+        'languages',
+    ],
+];

--- a/database/migrations/2025_12_22_000000_add_metadata_to_instructors_table.php
+++ b/database/migrations/2025_12_22_000000_add_metadata_to_instructors_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instructors', function (Blueprint $table): void {
+            $table->json('metadata')->nullable()->after('social_links');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('instructors', function (Blueprint $table): void {
+            $table->dropColumn('metadata');
+        });
+    }
+};

--- a/tests/Feature/Instructors/InstructorProfileEnrichmentTest.php
+++ b/tests/Feature/Instructors/InstructorProfileEnrichmentTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Instructor;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class)->group('instructors');
+
+beforeEach(function (): void {
+    Config::set('filesystems.default', 'public');
+    Storage::fake('public');
+});
+
+function makeInstructorUser(): User
+{
+    /** @var User $user */
+    $user = User::factory()->create([
+        'is_student' => true,
+        'password' => 'secret123',
+    ]);
+
+    return $user;
+}
+
+it('allows creating instructor with avatar and metadata', function (): void {
+    $user = makeInstructorUser();
+    $this->actingAs($user, 'api');
+
+    $avatar = UploadedFile::fake()->image('avatar.jpg');
+
+    $response = $this->post('/api/v1/instructors', [
+        'name_translations' => ['en' => 'John Doe'],
+        'bio_translations' => ['en' => 'Bio'],
+        'metadata' => [
+            'title' => 'Professor',
+            'languages' => ['en', 'ar'],
+        ],
+        'avatar' => $avatar,
+    ], ['Accept' => 'application/json']);
+
+    $response->assertCreated()
+        ->assertJsonPath('data.metadata.title', 'Professor')
+        ->assertJsonPath('data.metadata.languages.0', 'en');
+
+    $avatarUrl = (string) $response->json('data.avatar_url');
+    expect($avatarUrl)->not->toBe('');
+    $parsedPath = parse_url($avatarUrl, PHP_URL_PATH) ?? '';
+    $path = ltrim(str_replace('/storage/', '', $parsedPath), '/');
+    Storage::disk('public')->assertExists($path);
+});
+
+it('rejects unknown metadata keys', function (): void {
+    $user = makeInstructorUser();
+    $this->actingAs($user, 'api');
+
+    $response = $this->post('/api/v1/instructors', [
+        'name_translations' => ['en' => 'Jane Doe'],
+        'metadata' => [
+            'unknown_key' => 'value',
+        ],
+    ], ['Accept' => 'application/json']);
+
+    $response->assertStatus(422);
+});
+
+it('updates instructor bio and metadata', function (): void {
+    $user = makeInstructorUser();
+    $this->actingAs($user, 'api');
+
+    /** @var Instructor $instructor */
+    $instructor = Instructor::factory()->create([
+        'name_translations' => ['en' => 'Old Name'],
+    ]);
+
+    $response = $this->put("/api/v1/instructors/{$instructor->id}", [
+        'name_translations' => ['en' => 'New Name'],
+        'bio_translations' => ['en' => 'New Bio'],
+        'metadata' => ['specialization' => 'Math'],
+    ], ['Accept' => 'application/json']);
+
+    $response->assertOk()
+        ->assertJsonPath('data.name', 'New Name')
+        ->assertJsonPath('data.bio', 'New Bio')
+        ->assertJsonPath('data.metadata.specialization', 'Math');
+});


### PR DESCRIPTION
- Task: TASK-16
- GitHub Issue: #84
- Summary of changes:
  - Add instructor metadata allowlist config and persist metadata on instructors with new migration
  - Validate avatar uploads (jpeg/jpg/png/webp, <=500MB) and metadata keys/types; upload avatars via filesystem abstraction
  - Expose metadata in instructor resource and add feature tests for creation/update/validation
- What was NOT changed:
  - No changes to course, enrollment, playback, or student-facing flows
  - No instructor discovery or ratings features
- Tests added/updated:
  - tests/Feature/Instructors/InstructorProfileEnrichmentTest.php
- Link to issue #84