### PR TITLE
[LMS][TASK-17][#85] Admin route versioning alignment

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -36,25 +36,31 @@ return Application::configure(basePath: dirname(__DIR__))
                     });
                 });
 
-            // Admin (JWT)
+            // Admin (JWT) - canonical /api/v1/admin with backward-compatible /admin alias
+            $adminRoutes = static function (): void {
+                require __DIR__.'/../routes/admin/auth.php';
+
+                Route::middleware(['jwt.admin'])->group(function (): void {
+                    require __DIR__.'/../routes/admin/enrollments.php';
+                    require __DIR__.'/../routes/admin/courses.php';
+                    require __DIR__.'/../routes/admin/sections.php';
+                    require __DIR__.'/../routes/admin/videos.php';
+                    require __DIR__.'/../routes/admin/pdfs.php';
+                    require __DIR__.'/../routes/admin/center-settings.php';
+                    require __DIR__.'/../routes/admin/settings.php';
+                    require __DIR__.'/../routes/admin/audit-logs.php';
+                    require __DIR__.'/../routes/admin/extra-view-requests.php';
+                    require __DIR__.'/../routes/admin/device-change-requests.php';
+                });
+            };
+
+            Route::prefix('api/v1/admin')
+                ->middleware(['api'])
+                ->group($adminRoutes);
+
             Route::prefix('admin')
                 ->middleware(['api'])
-                ->group(function (): void {
-                    require __DIR__.'/../routes/admin/auth.php';
-
-                    Route::middleware(['jwt.admin'])->group(function (): void {
-                        require __DIR__.'/../routes/admin/enrollments.php';
-                        require __DIR__.'/../routes/admin/courses.php';
-                        require __DIR__.'/../routes/admin/sections.php';
-                        require __DIR__.'/../routes/admin/videos.php';
-                        require __DIR__.'/../routes/admin/pdfs.php';
-                        require __DIR__.'/../routes/admin/center-settings.php';
-                        require __DIR__.'/../routes/admin/settings.php';
-                        require __DIR__.'/../routes/admin/audit-logs.php';
-                        require __DIR__.'/../routes/admin/extra-view-requests.php';
-                        require __DIR__.'/../routes/admin/device-change-requests.php';
-                    });
-                });
+                ->group($adminRoutes);
         }
     )
     ->withCommands([

--- a/tests/Feature/AdminRoutes/AdminRouteVersioningTest.php
+++ b/tests/Feature/AdminRoutes/AdminRouteVersioningTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+it('exposes admin login via versioned and legacy prefixes', function (): void {
+    $this->postJson('/api/v1/admin/auth/login', [])->assertStatus(422);
+    $this->postJson('/admin/auth/login', [])->assertStatus(422);
+});
+
+it('requires authentication on protected admin routes for both prefixes', function (): void {
+    $this->getJson('/api/v1/admin/courses')->assertStatus(401);
+    $this->getJson('/admin/courses')->assertStatus(401);
+});


### PR DESCRIPTION
- Task: TASK-17
- GitHub Issue: #85
- Summary of changes:
  - Add canonical versioned admin route group under /api/v1/admin with backward-compatible /admin alias
  - Centralize admin route loading to reuse the same middleware stack and definitions
  - Add feature tests verifying both prefixes are available and protected
- What was NOT changed:
  - No controller or business logic changes
  - No request/response payload changes or deprecations applied yet
- Tests added/updated:
  - tests/Feature/AdminRoutes/AdminRouteVersioningTest.php
- Closes #85