### PR TITLE
[LMS][TASK-5D][#127] Upload Session Initialization Signed Upload URL

### DIFF
--- a/app/Services/Videos/VideoUploadService.php
+++ b/app/Services/Videos/VideoUploadService.php
@@ -34,7 +34,7 @@ class VideoUploadService
             'center_id' => $center->id,
             'uploaded_by' => $admin->id,
             'bunny_upload_id' => $bunnyId,
-            'upload_status' => self::STATUS_UPLOADING,
+            'upload_status' => self::STATUS_PENDING,
             'progress_percent' => 0,
         ]);
 
@@ -44,7 +44,7 @@ class VideoUploadService
             $video->source_provider = $video->source_provider ?: 'bunny';
             $video->source_type = $video->source_type ?: 1;
             $video->source_id = $bunnyId;
-            $this->applyVideoState($video, self::STATUS_UPLOADING, []);
+            $this->applyVideoState($video, self::STATUS_PENDING, []);
         }
 
         $session->setAttribute('upload_url', $created['upload_url']);

--- a/tests/Feature/Videos/VideoUpload/VideoUploadInitTest.php
+++ b/tests/Feature/Videos/VideoUpload/VideoUploadInitTest.php
@@ -21,7 +21,7 @@ it('creates bunny video and returns upload url', function (): void {
     ]);
 
     $response->assertCreated()
-        ->assertJsonPath('data.upload_status', VideoUploadService::STATUS_UPLOADING)
+        ->assertJsonPath('data.upload_status', VideoUploadService::STATUS_PENDING)
         ->assertJsonPath('data.bunny_upload_id', fn ($id) => is_string($id) && $id !== '')
         ->assertJsonPath('data.upload_url', fn ($url) => is_string($url) && $url !== '');
 
@@ -54,5 +54,5 @@ it('ties existing video to new upload session', function (): void {
     $video->refresh();
     expect($video->upload_session_id)->not->toBeNull()
         ->and($video->source_id)->not->toBeNull()
-        ->and($video->encoding_status)->toBe(VideoUploadService::STATUS_UPLOADING);
+        ->and($video->encoding_status)->toBe(VideoUploadService::STATUS_PENDING);
 });

--- a/tests/Feature/Videos/VideoUpload/VideoUploadLifecycleTest.php
+++ b/tests/Feature/Videos/VideoUpload/VideoUploadLifecycleTest.php
@@ -22,7 +22,7 @@ it('initializes an upload session for admin', function (): void {
     ]);
 
     $response->assertCreated()
-        ->assertJsonPath('data.upload_status', VideoUploadService::STATUS_UPLOADING)
+        ->assertJsonPath('data.upload_status', VideoUploadService::STATUS_PENDING)
         ->assertJsonPath('data.upload_url', fn ($url) => ! empty($url));
 
     $this->assertDatabaseHas('video_upload_sessions', [


### PR DESCRIPTION
- Task: TASK-5D
- GitHub Issue: #127
- Summary of changes:
  - Initialize Bunny videos via backend and persist upload sessions starting in PENDING state
  - Return scoped upload URLs to clients while keeping Bunny credentials server-side
  - Added feature tests covering upload session init and association with existing videos
- What was NOT changed:
  - No upload binaries handled by backend; no encoding lifecycle or playback logic touched
  - No schema changes or frontend modifications
- Tests added/updated:
  - tests/Feature/Videos/VideoUpload/VideoUploadInitTest.php
  - tests/Feature/Videos/VideoUpload/VideoUploadLifecycleTest.php
- Closes #127