### PR TITLE
[LMS][TASK-5G][#130] Admin Visibility Upload Sessions Uploaded Videos

### DIFF
--- a/app/Http/Controllers/Admin/VideoUploadSessionController.php
+++ b/app/Http/Controllers/Admin/VideoUploadSessionController.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\VideoUploadSessionResource;
+use App\Models\User;
+use App\Services\Videos\VideoUploadSessionQueryService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class VideoUploadSessionController extends Controller
+{
+    public function __construct(
+        private readonly VideoUploadSessionQueryService $queryService
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        /** @var User|null $admin */
+        $admin = $request->user();
+
+        if (! $admin instanceof User) {
+            return response()->json([
+                'success' => false,
+                'error' => [
+                    'code' => 'UNAUTHORIZED',
+                    'message' => 'Authentication required.',
+                ],
+            ], 401);
+        }
+
+        $perPage = (int) $request->integer('per_page', 15);
+        $filters = $request->only(['status', 'center_id']);
+
+        $paginator = $this->queryService->paginate($admin, $perPage, $filters);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Video upload sessions retrieved successfully',
+            'data' => VideoUploadSessionResource::collection($paginator->items()),
+            'meta' => [
+                'page' => $paginator->currentPage(),
+                'per_page' => $paginator->perPage(),
+                'total' => $paginator->total(),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Resources/VideoUploadSessionResource.php
+++ b/app/Http/Resources/VideoUploadSessionResource.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Video;
+use App\Models\VideoUploadSession;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin VideoUploadSession
+ */
+class VideoUploadSessionResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var VideoUploadSession $session */
+        $session = $this->resource;
+
+        return [
+            'id' => $session->id,
+            'center_id' => $session->center_id,
+            'uploaded_by' => $session->uploaded_by,
+            'bunny_upload_id' => $session->bunny_upload_id,
+            'upload_status' => $session->upload_status,
+            'progress_percent' => $session->progress_percent,
+            'error_message' => $session->error_message,
+            'created_at' => $session->created_at,
+            'updated_at' => $session->updated_at,
+            'videos' => $session->videos->map(static function (Video $video): array {
+                return [
+                    'id' => $video->id,
+                    'title' => $video->title,
+                    'encoding_status' => $video->encoding_status,
+                    'lifecycle_status' => $video->lifecycle_status,
+                    'source_id' => $video->source_id,
+                    'source_url' => $video->source_url,
+                    'original_filename' => $video->original_filename,
+                ];
+            }),
+        ];
+    }
+}

--- a/app/Services/Videos/VideoUploadSessionQueryService.php
+++ b/app/Services/Videos/VideoUploadSessionQueryService.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Videos;
+
+use App\Models\User;
+use App\Models\VideoUploadSession;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+
+class VideoUploadSessionQueryService
+{
+    /**
+     * @param  array<string, mixed>  $filters
+     * @return LengthAwarePaginator<VideoUploadSession>
+     */
+    public function paginate(User $admin, int $perPage = 15, array $filters = []): LengthAwarePaginator
+    {
+        $query = VideoUploadSession::query()
+            ->with(['videos'])
+            ->orderByDesc('created_at');
+
+        $query = $this->applyScope($query, $admin);
+        $query = $this->applyFilters($query, $filters);
+
+        return $query->paginate($perPage);
+    }
+
+    /**
+     * @param  Builder<VideoUploadSession>  $query
+     * @param  array<string, mixed>  $filters
+     * @return Builder<VideoUploadSession>
+     */
+    private function applyFilters(Builder $query, array $filters): Builder
+    {
+        if (isset($filters['status']) && is_numeric($filters['status'])) {
+            $query->where('upload_status', (int) $filters['status']);
+        }
+
+        if (isset($filters['center_id']) && is_numeric($filters['center_id'])) {
+            $query->where('center_id', (int) $filters['center_id']);
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param  Builder<VideoUploadSession>  $query
+     * @return Builder<VideoUploadSession>
+     */
+    private function applyScope(Builder $query, User $admin): Builder
+    {
+        if ($admin->center_id !== null) {
+            $query->where('center_id', $admin->center_id);
+        }
+
+        return $query;
+    }
+}

--- a/routes/admin/videos.php
+++ b/routes/admin/videos.php
@@ -2,9 +2,11 @@
 
 use App\Http\Controllers\Admin\CourseController;
 use App\Http\Controllers\Admin\VideoUploadController;
+use App\Http\Controllers\Admin\VideoUploadSessionController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/courses/{course}/videos', [CourseController::class, 'assignVideo']);
 Route::delete('/courses/{course}/videos/{video}', [CourseController::class, 'removeVideo']);
+Route::get('/video-upload-sessions', [VideoUploadSessionController::class, 'index']);
 Route::post('/video-uploads', [VideoUploadController::class, 'store']);
 Route::patch('/video-uploads/{videoUploadSession}', [VideoUploadController::class, 'update']);

--- a/tests/Feature/Admin/VideoUploadSessions/VideoUploadSessionListTest.php
+++ b/tests/Feature/Admin/VideoUploadSessions/VideoUploadSessionListTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Center;
+use App\Models\User;
+use App\Models\Video;
+use App\Models\VideoUploadSession;
+use App\Services\Videos\VideoUploadService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class)->group('videos');
+
+it('lists upload sessions for admin center', function (): void {
+    $center = Center::factory()->create();
+    $otherCenter = Center::factory()->create();
+
+    /** @var User $admin */
+    $admin = User::factory()->create([
+        'is_student' => false,
+        'center_id' => $center->id,
+    ]);
+
+    /** @var VideoUploadSession $session */
+    $session = VideoUploadSession::factory()->create([
+        'center_id' => $center->id,
+        'upload_status' => VideoUploadService::STATUS_FAILED,
+        'progress_percent' => 60,
+        'error_message' => 'Transcode failed',
+    ]);
+
+    /** @var Video $video */
+    $video = Video::factory()->create([
+        'upload_session_id' => $session->id,
+        'encoding_status' => VideoUploadService::STATUS_PROCESSING,
+        'lifecycle_status' => 1,
+    ]);
+
+    VideoUploadSession::factory()->create(['center_id' => $otherCenter->id]);
+
+    $response = $this->actingAs($admin, 'admin')->getJson('/api/v1/admin/video-upload-sessions?per_page=10');
+
+    $response->assertOk()
+        ->assertJsonPath('meta.total', 1)
+        ->assertJsonPath('data.0.id', $session->id)
+        ->assertJsonPath('data.0.upload_status', VideoUploadService::STATUS_FAILED)
+        ->assertJsonPath('data.0.error_message', 'Transcode failed')
+        ->assertJsonPath('data.0.videos.0.id', $video->id)
+        ->assertJsonPath('data.0.videos.0.encoding_status', VideoUploadService::STATUS_PROCESSING);
+});
+
+it('requires authentication', function (): void {
+    $response = $this->getJson('/api/v1/admin/video-upload-sessions');
+
+    $response->assertStatus(401);
+});


### PR DESCRIPTION
 - Task: TASK-5G
      - GitHub Issue: #130
      - Summary of changes:
          - Added admin VideoUploadSessionController with paginated listing scoped by center and filters for
            status/center.
          - Added VideoUploadSessionQueryService and VideoUploadSessionResource exposing session status,
            progress, errors, and related video metadata.
          - Added route GET /api/v1/admin/video-upload-sessions (and /admin alias) and feature test covering
            scoped listing/auth.
      - What was NOT changed: no upload initiation, no playback/encoding logic, no UI adjustments.
      - Tests added/updated: tests/Feature/Admin/VideoUploadSessions/VideoUploadSessionListTest.php
      - Note: Tests not run locally (Docker daemon access denied).
      - closes #130 